### PR TITLE
Optimize regex handling with caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,6 +550,7 @@ dependencies = [
  "imageproc",
  "ipnet",
  "lru",
+ "once_cell",
  "prost",
  "prost-build",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,9 @@ thiserror = "1.0"
 dashmap = "5.5"
 lru = "0.12"
 
+# 全局静态初始化
+once_cell = "1"
+
 # 时间处理
 chrono = { version = "0.4", features = ["serde"] }
 


### PR DESCRIPTION
## Summary
- cache compiled regex patterns to avoid recompilation
- use global cache in detector to reduce repeated allocations
- add once_cell dependency

## Testing
- `cargo check`
- `cargo test` *(fails: core::identity_tests::expiry_and_cleanup_tests::test_partial_cleanup; other tests running >60s)*

------
https://chatgpt.com/codex/tasks/task_b_689def185ffc8325bead2faf23bed56f