### PR TITLE
Improve cache precision and cleanup logic

### DIFF
--- a/src/core/cache_tests.rs
+++ b/src/core/cache_tests.rs
@@ -536,10 +536,10 @@ mod serializable_cache_item_tests {
 
         let expired_serializable = SerializableCacheItem {
             value: "expired_value".to_string(),
-            expires_at_secs: expired_time
+            expires_at_millis: expired_time
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap()
-                .as_secs(),
+                .as_millis(),
         };
 
         // 尝试转换已过期的项应该失败

--- a/src/core/captcha.rs
+++ b/src/core/captcha.rs
@@ -92,7 +92,7 @@ impl CaptchaService {
 
         challenges.retain(
             |_, challenge| match now.duration_since(challenge.created_at) {
-                Ok(elapsed) => elapsed <= challenge.ttl,
+                Ok(elapsed) => elapsed < challenge.ttl,
                 Err(_) => false,
             },
         );

--- a/src/http/server.rs
+++ b/src/http/server.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use axum::{
     body::Body,
-    extract::{ConnectInfo, Path, Request},
+    extract::{Path, Request},
     response::Response,
     routing::{get, post},
     serve, Router,
@@ -138,10 +138,7 @@ async fn captcha_gen_handler(Path(_challenge_id): Path<String>) -> Response<Body
         .unwrap()
 }
 
-async fn fallback_handler(
-    _connect_info: ConnectInfo<SocketAddr>,
-    _request: Request<Body>,
-) -> Response<Body> {
+async fn fallback_handler(_request: Request<Body>) -> Response<Body> {
     // 简单的404响应，暂时不调用WAF处理器
     Response::builder()
         .status(404)


### PR DESCRIPTION
## Summary
- preserve millisecond precision in serialized cache items
- sort session requests deterministically and tighten TTL expiration
- extend attack detection patterns and clean up fallback handler

## Testing
- `cargo test core::cache_tests::serializable_cache_item_tests::test_serializable_cache_item_conversion`
- `cargo test core::identity_tests::session_management_tests::test_get_session_requests`
- `cargo test core::captcha_tests::captcha_expiry_tests::test_partial_cleanup_expired_challenges`
- `cargo test core::identity_tests::expiry_and_cleanup_tests::test_partial_cleanup`


------
https://chatgpt.com/codex/tasks/task_b_689eb8caa3d8832594582ccc42521ed8